### PR TITLE
Allow for queueIgnores to be applied at queue name retrieval time

### DIFF
--- a/src/main/java/com/newrelic/infra/ibmmq/QueueMetricCollector.java
+++ b/src/main/java/com/newrelic/infra/ibmmq/QueueMetricCollector.java
@@ -44,6 +44,14 @@ public class QueueMetricCollector {
 			PCFMessage inquireQueue = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q); 
 
 			inquireQueue.addParameter(MQConstants.MQCA_Q_NAME, "*");
+
+			// In cases where large numbers of queues are reported from a slow queue manager, timeouts were occurring on retrieving queue names
+			// Allows for filtering of queue names from the existing queueIgnores list using the addFilterParameter PCFMessage function
+			for (Pattern ignorePattern : agentConfig.queueIgnores) {
+				logger.debug("Adding ignore pattern to filters: " + ignorePattern.toString());
+				inquireQueue.addFilterParameter(MQConstants.MQCA_Q_NAME, MQConstants.MQCFOP_NOT_LIKE, ignorePattern.toString());
+			}
+
 			inquireQueue.addParameter(MQConstants.MQIA_Q_TYPE, MQConstants.MQQT_LOCAL);
 			inquireQueue.addParameter(MQConstants.MQIACF_Q_ATTRS,
 					new int[] { 


### PR DESCRIPTION
### Problem: Large number of queues being pulled with (*) filter causing MQ 2033 timeouts

During queries of slow queue managers in trying to retrieve all queues, we were observing MQ 2033 timeouts resulting in no response at all being sent to New Relic (beyond maybe channel metrics, which were retrieving quickly).

### Fix: Apply queueIgnore filtering before queue name retrieval

During metric collection, instead of grabbing all queue names and then verifying if they should be ignored, added in a step to apply the PCFMessage **addFilterParameter** function.

By borrowing logic from the existing **isQueueIgnored** function, the inquireQueue object now adds each ignored queue from the config into the PCFMessage filter parameters, (potentially) drastically reducing the number of queues requested for retrieval from the queue manager.